### PR TITLE
Only retry when failure likely to be intermittent

### DIFF
--- a/SurveyMonkey/SurveyMonkeyApi.Infrastructure.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Infrastructure.cs
@@ -114,9 +114,9 @@ namespace SurveyMonkey
                     string result = _webClient.DownloadString(url);
                     return result;
                 }
-                catch (WebException)
+                catch (WebException ex)
                 {
-                    if (attempt < _retrySequence.Length)
+                    if (attempt < _retrySequence.Length && (ex.Response == null || ((HttpWebResponse)ex.Response).StatusCode == HttpStatusCode.ServiceUnavailable))
                     {
                         Thread.Sleep(_retrySequence[attempt] * 1000);
                     }


### PR DESCRIPTION
If we have a response, it's very likely to be a message from the api that something was wrong with the request, which won't be rectified by just retrying after a delay. The retry logic is meant to help with temporary connectivity issues; when the request itself was bad it's better to throw immediately. Otherwise it just looks like the library is hanging.