### PR TITLE
Multiple fixes, added basic support for creating collectors.

### DIFF
--- a/SurveyMonkey/Containers/Question.cs
+++ b/SurveyMonkey/Containers/Question.cs
@@ -21,5 +21,6 @@ namespace SurveyMonkey.Containers
         internal string Href { get; set; }
         public QuestionAnswers Answers { get; set; }
         public string Nickname { get; set; }
+        public QuestionDisplayOptions DisplayOptions { get; set; }
     }
 }

--- a/SurveyMonkey/Containers/QuestionDisplayOptions.cs
+++ b/SurveyMonkey/Containers/QuestionDisplayOptions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using SurveyMonkey.Enums;
+
+namespace SurveyMonkey.Containers
+{
+    [JsonConverter(typeof(TolerantJsonConverter))]
+    public class QuestionDisplayOptions : IPageableContainer
+    {
+        public string MiddleLabel { get; set; }
+        public bool ShowDisplayNumber { get; set; }
+        public string DisplaySubtype { get; set; }
+        public string RightLabel { get; set; }
+        public string DisplayType { get; set; }
+        public string LeftLabel { get; set; }
+
+        public QuestionDisplayOptionsCustomOptions CustomOptions { get; set; }
+
+    }
+}

--- a/SurveyMonkey/Containers/QuestionDisplayOptions.cs
+++ b/SurveyMonkey/Containers/QuestionDisplayOptions.cs
@@ -12,7 +12,7 @@ namespace SurveyMonkey.Containers
     public class QuestionDisplayOptions : IPageableContainer
     {
         public string MiddleLabel { get; set; }
-        public bool ShowDisplayNumber { get; set; }
+        public bool? ShowDisplayNumber { get; set; }
         public string DisplaySubtype { get; set; }
         public string RightLabel { get; set; }
         public string DisplayType { get; set; }

--- a/SurveyMonkey/Containers/QuestionDisplayOptionsCustomOptions.cs
+++ b/SurveyMonkey/Containers/QuestionDisplayOptionsCustomOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using SurveyMonkey.Enums;
+
+namespace SurveyMonkey.Containers
+{
+    [JsonConverter(typeof(TolerantJsonConverter))]
+    public class QuestionDisplayOptionsCustomOptions : IPageableContainer
+    {
+    }
+}

--- a/SurveyMonkey/Containers/Survey.cs
+++ b/SurveyMonkey/Containers/Survey.cs
@@ -10,8 +10,10 @@ namespace SurveyMonkey.Containers
     {
         public long? Id { get; set; }
         public string Title { get; set; }
+        public string Nickname { get; set; }
         public string Category { get; set; }
         public string Language { get; set; }
+        public bool IsOwner { get; set; }
         public int? PageCount { get; set; }
         public int? QuestionCount { get; set; }
         public int? ResponseCount { get; set; }

--- a/SurveyMonkey/Containers/Survey.cs
+++ b/SurveyMonkey/Containers/Survey.cs
@@ -13,7 +13,7 @@ namespace SurveyMonkey.Containers
         public string Nickname { get; set; }
         public string Category { get; set; }
         public string Language { get; set; }
-        public bool IsOwner { get; set; }
+        public bool? IsOwner { get; set; }
         public int? PageCount { get; set; }
         public int? QuestionCount { get; set; }
         public int? ResponseCount { get; set; }

--- a/SurveyMonkey/RequestSettings/CreateCollectorSettings.cs
+++ b/SurveyMonkey/RequestSettings/CreateCollectorSettings.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SurveyMonkey.RequestSettings
+{
+    public class CreateCollectorSettings
+    {
+        public enum TypeOption
+        {
+            weblink,
+            email
+        }
+
+        public TypeOption type { get; set; }
+        public string name { get; set; }
+
+    }
+}

--- a/SurveyMonkey/SurveyMonkey.csproj
+++ b/SurveyMonkey/SurveyMonkey.csproj
@@ -11,6 +11,10 @@
     <AssemblyName>SurveyMonkeyApi</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -81,6 +85,8 @@
     <Compile Include="Containers\Member.cs" />
     <Compile Include="Containers\Group.cs" />
     <Compile Include="Containers\IPageableContainer.cs" />
+    <Compile Include="Containers\QuestionDisplayOptions.cs" />
+    <Compile Include="Containers\QuestionDisplayOptionsCustomOptions.cs" />
     <Compile Include="Containers\Recipient.cs" />
     <Compile Include="Containers\Message.cs" />
     <Compile Include="Containers\OtherAnswer.cs" />
@@ -133,6 +139,7 @@
     <Compile Include="ProcessedAnswers\ProcessedAnswer.cs" />
     <Compile Include="ProcessedAnswers\MultipleChoiceAnswer.cs" />
     <Compile Include="ProcessedAnswers\SingleChoiceAnswer.cs" />
+    <Compile Include="RequestSettings\CreateCollectorSettings.cs" />
     <Compile Include="RequestSettings\IPagingSettings.cs" />
     <Compile Include="SurveyMonkeyApi.Users.cs" />
     <Compile Include="SurveyMonkeyApi.DataProcessing.cs" />

--- a/SurveyMonkey/SurveyMonkeyApi.Collectors.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Collectors.cs
@@ -9,6 +9,16 @@ namespace SurveyMonkey
 {
     public partial class SurveyMonkeyApi
     {
+        public Collector CreateCollector(long surveyId, CreateCollectorSettings settings)
+        {
+            string endPoint = String.Format("/surveys/{0}/collectors", surveyId);
+            var verb = Verb.POST;
+            var requestData = SurveyMonkey.Helpers.RequestSettingsHelper.GetPopulatedProperties(settings);
+            JToken result = MakeApiRequest(endPoint, verb, requestData);
+            var collector = result.ToObject<Collector>();
+            return collector;
+        }
+
         public List<Collector> GetCollectorList(long surveyId)
         {
             var settings = new GetCollectorListSettings();

--- a/SurveyMonkey/SurveyMonkeyApi.Infrastructure.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Infrastructure.cs
@@ -79,7 +79,10 @@ namespace SurveyMonkey
             var url = "https://api.surveymonkey.net/v3" + endpoint;
             _webClient.Headers.Add("Content-Type", "application/json");
             _webClient.Headers.Add("Authorization", "bearer " + _oAuthToken);
-            _webClient.QueryString.Add("api_key", _apiKey);
+            if (!string.IsNullOrEmpty(_apiKey))
+            {
+                _webClient.QueryString.Add("api_key", _apiKey);
+            }
             if (verb == Verb.GET)
             {
                 foreach (var item in data)


### PR DESCRIPTION
- SurveyMonkey/Containers/Question.cs - I added the DisplayOptions property

- SurveyMonkey/Containers/QuestionDisplayOptions.cs - This is the class to support the above DisplayOptions property

- SurveyMonkey/Containers/QuestionDisplayOptionsCustomOptions.cs - Another class to support the above DisplayOptions property

- SurveyMonkey/Containers/Survey.cs - Added the Nickname and IsOwner properties

- SurveyMonkey/RequestSettings/CreateCollectorSettings.cs - A new class to support creation of Collectors.  This is a very basic frame and doesn't have all of the options set up.

- SurveyMonkey/SurveyMonkey.csproj - Included the new class files

- SurveyMonkey/SurveyMonkeyApi.Collectors.cs - Added the CreateCollector method

- SurveyMonkey/SurveyMonkeyApi.Infrastructure.cs - Modified to only add api_key onto the query string if it's specified.  It is not required for some types of authentication to SurveyMonkey.