### PR TITLE
Show the api's error messages.

### DIFF
--- a/SurveyMonkey/Containers/Error.cs
+++ b/SurveyMonkey/Containers/Error.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+
+namespace SurveyMonkey.Containers
+{
+    [JsonConverter(typeof(TolerantJsonConverter))]
+    internal class Error
+    {
+        public string Docs { get; set; }
+        public string Message { get; set; }
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public int? HttpStatusCode { get; set; }
+    }
+}

--- a/SurveyMonkey/SurveyMonkey.csproj
+++ b/SurveyMonkey/SurveyMonkey.csproj
@@ -78,6 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Containers\ButtonsText.cs" />
+    <Compile Include="Containers\Error.cs" />
     <Compile Include="Containers\Member.cs" />
     <Compile Include="Containers\Group.cs" />
     <Compile Include="Containers\IPageableContainer.cs" />


### PR DESCRIPTION
When receiving an error from the api, attempt to pick out the useful information and include in the exception. If it's a scope error (which seems very common because of lacking documentation), message specifically about that.