### PR TITLE
Page more responses at once

### DIFF
--- a/SurveyMonkey/SurveyMonkeyApi.Infrastructure.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Infrastructure.cs
@@ -14,8 +14,8 @@ namespace SurveyMonkey
 {
     public partial class SurveyMonkeyApi : IDisposable, ISurveyMonkeyApi
     {
-        private string _apiKey;
-        private string _accessToken;
+        private readonly string _apiKey;
+        private readonly string _accessToken;
         private IWebClient _webClient;
         private DateTime _lastRequestTime = DateTime.MinValue;
         private readonly int _rateLimitDelay = 500;

--- a/SurveyMonkey/SurveyMonkeyApi.Responses.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Responses.cs
@@ -93,7 +93,7 @@ namespace SurveyMonkey
         {
             var bulk = details ? "/bulk" : String.Empty;
             string endPoint = String.Format("/{0}s/{1}/responses{2}", objectType.ToString().ToLower(), id, bulk);
-            const int maxResultsPerPage = 100;
+            int maxResultsPerPage = details ? 100 : 1000;
             var results = Page(settings, endPoint, typeof(List<Response>), maxResultsPerPage);
             return results.ToList().ConvertAll(o => (Response)o);
         }

--- a/SurveyMonkeyTests/GetResponseTests.cs
+++ b/SurveyMonkeyTests/GetResponseTests.cs
@@ -191,7 +191,7 @@ namespace SurveyMonkeyTests
                 {""per_page"":100,""total"":300,""data"":[],""page"":4,""links"":{""self"":""https:\/\/api.surveymonkey.net\/v3\/surveys\/?page=4&per_page=100""}}
             ");
             var api = new SurveyMonkeyApi("TestApiKey", "TestOAuthToken", client);
-            var results = api.GetCollectorResponseOverviewList(91395530, new GetResponseListSettings {Custom = "asdf"});
+            var results = api.GetCollectorResponseDetailsList(91395530, new GetResponseListSettings {Custom = "asdf"});
             Assert.AreEqual(300, results.Count);
             Assert.AreEqual(300, results.Last().Id);
             Assert.AreEqual(1, results.First().Id);


### PR DESCRIPTION
When fetching the non-detailed response lists, the api is happy to do pages of 1000, rather than 100 which is all it will provide when requesting the answers.