### PR TITLE
Support recipients for collector instead of message

### DIFF
--- a/SurveyMonkey/ISurveyMonkeyApi.cs
+++ b/SurveyMonkey/ISurveyMonkeyApi.cs
@@ -30,8 +30,10 @@ namespace SurveyMonkey
         List<Message> GetMessageList(long collectorId);
         List<Message> GetMessageList(long collectorId, PagingSettings settings);
         Message GetMessageDetails(long collectorId, long messageId);
-        List<Recipient> GetRecipientList(long collectorId, long messageId);
-        List<Recipient> GetRecipientList(long collectorId, long messageId, PagingSettings settings);
+        List<Recipient> GetCollectorRecipientList(long collectorId);
+        List<Recipient> GetCollectorRecipientList(long collectorId, PagingSettings settings);
+        List<Recipient> GetMessageRecipientList(long collectorId, long messageId);
+        List<Recipient> GetMessageRecipientList(long collectorId, long messageId, PagingSettings settings);
         Recipient GetRecipientDetails(long collectorId, long recipientId);
         List<SurveyCategory> GetSurveyCategoryList();
         List<SurveyCategory> GetSurveyCategoryList(GetSurveyCategoryListSettings settings);

--- a/SurveyMonkey/SurveyMonkeyApi.Collectors.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Collectors.cs
@@ -75,6 +75,18 @@ namespace SurveyMonkey
             return message;
         }
 
+        [Obsolete("GetRecipientList() is obsolete. Either use GetMessageRecipientList() or GetCollectorRecipientList().", true)]
+        public List<Recipient> GetRecipientList(long collectorId, long messageId)
+        {
+            return GetMessageRecipientList(collectorId, messageId);
+        }
+
+        [Obsolete("GetRecipientList() is obsolete. Either use GetMessageRecipientList() or GetCollectorRecipientList().", true)]
+        public List<Recipient> GetRecipientList(long collectorId, long messageId, PagingSettings settings)
+        {
+            return GetMessageRecipientList(collectorId, messageId, settings);
+        }
+
         public List<Recipient> GetCollectorRecipientList(long collectorId)
         {
             var settings = new PagingSettings();

--- a/SurveyMonkey/SurveyMonkeyApi.Collectors.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Collectors.cs
@@ -75,6 +75,25 @@ namespace SurveyMonkey
             return message;
         }
 
+        public List<Recipient> GetCollectorRecipientList(long collectorId)
+        {
+            var settings = new PagingSettings();
+            return GetCollectorRecipientListPager(collectorId, settings);
+        }
+
+        public List<Recipient> GetCollectorRecipientList(long collectorId, PagingSettings settings)
+        {
+            return GetCollectorRecipientListPager(collectorId, settings);
+        }
+
+        private List<Recipient> GetCollectorRecipientListPager(long collectorId, IPagingSettings settings)
+        {
+            string endPoint = String.Format("/collectors/{0}/recipients", collectorId);
+            const int maxResultsPerPage = 1000;
+            var results = Page(settings, endPoint, typeof(List<Recipient>), maxResultsPerPage);
+            return results.ToList().ConvertAll(o => (Recipient)o);
+        }
+
         public List<Recipient> GetRecipientList(long collectorId, long messageId)
         {
             var settings = new PagingSettings();

--- a/SurveyMonkey/SurveyMonkeyApi.Collectors.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Collectors.cs
@@ -90,36 +90,30 @@ namespace SurveyMonkey
         public List<Recipient> GetCollectorRecipientList(long collectorId)
         {
             var settings = new PagingSettings();
-            return GetCollectorRecipientListPager(collectorId, settings);
+            return GetRecipientListPager(collectorId, null, settings);
         }
 
         public List<Recipient> GetCollectorRecipientList(long collectorId, PagingSettings settings)
         {
-            return GetCollectorRecipientListPager(collectorId, settings);
+            return GetRecipientListPager(collectorId, null, settings);
         }
-
-        private List<Recipient> GetCollectorRecipientListPager(long collectorId, IPagingSettings settings)
-        {
-            string endPoint = String.Format("/collectors/{0}/recipients", collectorId);
-            const int maxResultsPerPage = 1000;
-            var results = Page(settings, endPoint, typeof(List<Recipient>), maxResultsPerPage);
-            return results.ToList().ConvertAll(o => (Recipient)o);
-        }
-
+        
         public List<Recipient> GetMessageRecipientList(long collectorId, long messageId)
         {
             var settings = new PagingSettings();
-            return GetMessageRecipientListPager(collectorId, messageId, settings);
+            return GetRecipientListPager(collectorId, messageId, settings);
         }
 
         public List<Recipient> GetMessageRecipientList(long collectorId, long messageId, PagingSettings settings)
         {
-            return GetMessageRecipientListPager(collectorId, messageId, settings);
+            return GetRecipientListPager(collectorId, messageId, settings);
         }
 
-        private List<Recipient> GetMessageRecipientListPager(long collectorId, long messageId, IPagingSettings settings)
+        private List<Recipient> GetRecipientListPager(long collectorId, long? messageId, IPagingSettings settings)
         {
-            string endPoint = String.Format("/collectors/{0}/messages/{1}/recipients", collectorId, messageId);
+            string endPoint = messageId.HasValue ?
+                String.Format("/collectors/{0}/messages/{1}/recipients", collectorId, messageId) :
+                String.Format("/collectors/{0}/recipients", collectorId);
             const int maxResultsPerPage = 1000;
             var results = Page(settings, endPoint, typeof(List<Recipient>), maxResultsPerPage);
             return results.ToList().ConvertAll(o => (Recipient)o);

--- a/SurveyMonkey/SurveyMonkeyApi.Collectors.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Collectors.cs
@@ -94,18 +94,18 @@ namespace SurveyMonkey
             return results.ToList().ConvertAll(o => (Recipient)o);
         }
 
-        public List<Recipient> GetRecipientList(long collectorId, long messageId)
+        public List<Recipient> GetMessageRecipientList(long collectorId, long messageId)
         {
             var settings = new PagingSettings();
-            return GetRecipientListPager(collectorId, messageId, settings);
+            return GetMessageRecipientListPager(collectorId, messageId, settings);
         }
 
-        public List<Recipient> GetRecipientList(long collectorId, long messageId, PagingSettings settings)
+        public List<Recipient> GetMessageRecipientList(long collectorId, long messageId, PagingSettings settings)
         {
-            return GetRecipientListPager(collectorId, messageId, settings);
+            return GetMessageRecipientListPager(collectorId, messageId, settings);
         }
 
-        private List<Recipient> GetRecipientListPager(long collectorId, long messageId, IPagingSettings settings)
+        private List<Recipient> GetMessageRecipientListPager(long collectorId, long messageId, IPagingSettings settings)
         {
             string endPoint = String.Format("/collectors/{0}/messages/{1}/recipients", collectorId, messageId);
             const int maxResultsPerPage = 1000;

--- a/SurveyMonkeyTests/GetCollectorTests.cs
+++ b/SurveyMonkeyTests/GetCollectorTests.cs
@@ -105,7 +105,7 @@ namespace SurveyMonkeyTests
                 {""per_page"":1000,""total"":2,""data"":[{""href"":""https:\/\/api.surveymonkey.net\/v3\/collectors\/85470742\/recipients\/2407626836"",""id"":""2407626836"",""email"":""test+12@gmail.com""},{""href"":""https:\/\/api.surveymonkey.net\/v3\/collectors\/85470742\/recipients\/2407626837"",""id"":""2407626837"",""email"":""test+13@gmail.com""}],""page"":1,""links"":{""self"":""https:\/\/api.surveymonkey.net\/v3\/collectors\/85470742\/messages\/29296390\/recipients?page=1&per_page=1000""}}
             ");
             var api = new SurveyMonkeyApi("TestApiKey", "TestOAuthToken", client);
-            var result = api.GetRecipientList(85470742, 29296390);
+            var result = api.GetMessageRecipientList(85470742, 29296390);
             Assert.AreEqual(2, result.Count);
             Assert.AreEqual("https://api.surveymonkey.net/v3/collectors/85470742/recipients/2407626836", result.First().Href);
             Assert.AreEqual(2407626836, result.First().Id);

--- a/SurveyMonkeyTests/GetCollectorTests.cs
+++ b/SurveyMonkeyTests/GetCollectorTests.cs
@@ -98,7 +98,7 @@ namespace SurveyMonkeyTests
         }
 
         [Test]
-        public void GetRecipientListIsDeserialised()
+        public void GetMessageRecipientListIsDeserialised()
         {
             var client = new MockWebClient();
             client.Responses.Add(@"
@@ -110,6 +110,21 @@ namespace SurveyMonkeyTests
             Assert.AreEqual("https://api.surveymonkey.net/v3/collectors/85470742/recipients/2407626836", result.First().Href);
             Assert.AreEqual(2407626836, result.First().Id);
             Assert.AreEqual("test+13@gmail.com", result.Last().Email);
+            Assert.IsNull(result.First().MailStatus);
+        }
+
+        [Test]
+        public void GetCollectorRecipientListIsDeserialised()
+        {
+            var client = new MockWebClient();
+            client.Responses.Add(@"
+                {""per_page"":1000,""total"":2,""data"":[{""href"":""https:\/\/api.surveymonkey.net\/v3\/collectors\/94732812\/recipients\/2751878525"",""id"":""2751878525"",""email"":""test1@test123456789.com""},{""href"":""https:\/\/api.surveymonkey.net\/v3\/collectors\/94732812\/recipients\/2751878526"",""id"":""2751878526"",""email"":""test2@test123456789.com""}],""page"":1,""links"":{""self"":""https:\/\/api.surveymonkey.net\/v3\/collectors\/94732812\/recipients?page=1&per_page=1000""}}
+            ");
+            var api = new SurveyMonkeyApi("TestApiKey", "TestOAuthToken", client);
+            var result = api.GetCollectorRecipientList(94732812);
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(2751878525, result.First().Id);
+            Assert.AreEqual("test2@test123456789.com", result.Last().Email);
             Assert.IsNull(result.First().MailStatus);
         }
 


### PR DESCRIPTION
This endpoint was added by SurveyMonkey on 13th October, and requested in #34. It allows fetching recipients of a collector, in addition to the previous ability to fetch recipients of an individual message. Unfortunately this contains a breaking public api change, because GetRecipientList() has now become GetMessageRecipientList() and GetCollectorRecipientList().