### PR TITLE
Provide specific warning for TLS connection errors

### DIFF
--- a/SurveyMonkey/SurveyMonkeyApi.Infrastructure.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Infrastructure.cs
@@ -145,6 +145,12 @@ namespace SurveyMonkey
                 }
                 catch (WebException webEx)
                 {
+                    if (webEx.Status == WebExceptionStatus.SecureChannelFailure)
+                    {
+                        throw new WebException("SSL/TLS error. SurveyMonkey requires TLS 1.2, as of 13 June 2018. "
+                            + "Configure this globally with \"ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;\" anywhere before using this library. "
+                            + "See https://github.com/bcemmett/SurveyMonkeyApi-v3/issues/66 for details.", webEx);
+                    }
                     if (attempt < _retrySequence.Length && (webEx.Response == null || ((HttpWebResponse)webEx.Response).StatusCode == HttpStatusCode.ServiceUnavailable))
                     {
                         Thread.Sleep(_retrySequence[attempt] * 1000);


### PR DESCRIPTION
As per #66, SurveyMonkey started enforcing TLS 1.2.

.NET unfortunately only allows this to be configured per appdomain rather than just for this library. Given that this could break other code running in the same app, I don't think this library should change that setting unannounced, even though that means this library can fail on old systems. As a compromise, we'll detect this error and provide specific guidance.