### PR TITLE
Build for .NET 5

### DIFF
--- a/SurveyMonkey.sln
+++ b/SurveyMonkey.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31229.75
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SurveyMonkey", "SurveyMonkey\SurveyMonkey.csproj", "{8046D9E9-7851-4837-860D-CC546D51AE57}"
 EndProject

--- a/SurveyMonkey/Helpers/RequestSettingsHelper.cs
+++ b/SurveyMonkey/Helpers/RequestSettingsHelper.cs
@@ -12,35 +12,35 @@ namespace SurveyMonkey.Helpers
             var output = new RequestData();
             foreach (PropertyInfo property in obj.GetType().GetProperties(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
             {
-                if (property.GetValue(obj, null) != null)
+                if (property.GetValue(obj) != null)
                 {
                     Type underlyingType = property.PropertyType.IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>)
                         ? Nullable.GetUnderlyingType(property.PropertyType)
                         : property.PropertyType;
                     if (underlyingType.IsEnum)
                     {
-                        output.Add(PropertyCasingHelper.CamelToSnake(property.Name), PropertyCasingHelper.CamelToSnake(property.GetValue(obj, null).ToString()));
+                        output.Add(PropertyCasingHelper.CamelToSnake(property.Name), PropertyCasingHelper.CamelToSnake(property.GetValue(obj).ToString()));
                     }
                     else if (underlyingType == typeof(DateTime))
                     {
-                        output.Add(PropertyCasingHelper.CamelToSnake(property.Name), ((DateTime)property.GetValue(obj, null)).ToString("s"));
+                        output.Add(PropertyCasingHelper.CamelToSnake(property.Name), ((DateTime)property.GetValue(obj)).ToString("s"));
                     }
                     else if (underlyingType == typeof(List<DateTime>))
                     {
-                        output.Add(PropertyCasingHelper.CamelToSnake(property.Name), ((List<DateTime>)property.GetValue(obj, null)).ConvertAll(x => x.ToString("s")));
+                        output.Add(PropertyCasingHelper.CamelToSnake(property.Name), ((List<DateTime>)property.GetValue(obj)).ConvertAll(x => x.ToString("s")));
                     }
                     //SurveyMonkey uses strings to represent longs (eg for any Ids)
                     else if (underlyingType == typeof(long))
                     {
-                        output.Add(PropertyCasingHelper.CamelToSnake(property.Name), ((long)property.GetValue(obj, null)).ToString());
+                        output.Add(PropertyCasingHelper.CamelToSnake(property.Name), ((long)property.GetValue(obj)).ToString());
                     }
                     else if (underlyingType == typeof(List<long>))
                     {
-                        output.Add(PropertyCasingHelper.CamelToSnake(property.Name), ((List<long>)property.GetValue(obj, null)).ConvertAll(x => x.ToString()));
+                        output.Add(PropertyCasingHelper.CamelToSnake(property.Name), ((List<long>)property.GetValue(obj)).ConvertAll(x => x.ToString()));
                     }
                     else
                     {
-                        output.Add(PropertyCasingHelper.CamelToSnake(property.Name), property.GetValue(obj, null));
+                        output.Add(PropertyCasingHelper.CamelToSnake(property.Name), property.GetValue(obj));
                     }
 
                 }

--- a/SurveyMonkey/SurveyMonkey.csproj
+++ b/SurveyMonkey/SurveyMonkey.csproj
@@ -16,7 +16,7 @@
     <DelaySign>false</DelaySign>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
-    <TargetFrameworks>net40;net45;net451;net451;net452;net46;net461;net462;net47;net471;netcoreapp2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net451;net451;net452;net46;net461;net462;net47;net471;netcoreapp2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <TargetFramework>net5.0</TargetFramework>

--- a/SurveyMonkey/SurveyMonkey.csproj
+++ b/SurveyMonkey/SurveyMonkey.csproj
@@ -16,10 +16,10 @@
     <DelaySign>false</DelaySign>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
-    <TargetFrameworks>net40;net45;net451;net451;net452;net46;net461;net462;net47;net471;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net451;net451;net452;net46;net461;net462;net47;net471;netcoreapp2.0;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/SurveyMonkey/SurveyMonkey.csproj
+++ b/SurveyMonkey/SurveyMonkey.csproj
@@ -22,6 +22,6 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/SurveyMonkey/SurveyMonkey.csproj
+++ b/SurveyMonkey/SurveyMonkey.csproj
@@ -16,7 +16,7 @@
     <DelaySign>false</DelaySign>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
-    <TargetFrameworks>net40;net45;net451;net451;net452;net46;net461;net462;net47;net471;netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;net451;net451;net452;net46;net461;net462;net47;net471;netcoreapp2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <TargetFramework>net5.0</TargetFramework>

--- a/SurveyMonkey/SurveyMonkey.nuspec
+++ b/SurveyMonkey/SurveyMonkey.nuspec
@@ -17,7 +17,6 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="bin\Release\net40\SurveyMonkeyApi.dll" target="lib\net40\SurveyMonkeyApi.dll" />
         <file src="bin\Release\net45\SurveyMonkeyApi.dll" target="lib\net45\SurveyMonkeyApi.dll" />
         <file src="bin\Release\net451\SurveyMonkeyApi.dll" target="lib\net451\SurveyMonkeyApi.dll" />
         <file src="bin\Release\net452\SurveyMonkeyApi.dll" target="lib\net452\SurveyMonkeyApi.dll" />

--- a/SurveyMonkey/SurveyMonkey.nuspec
+++ b/SurveyMonkey/SurveyMonkey.nuspec
@@ -26,7 +26,7 @@
         <file src="bin\Release\net462\SurveyMonkeyApi.dll" target="lib\net462\SurveyMonkeyApi.dll" />
         <file src="bin\Release\net47\SurveyMonkeyApi.dll" target="lib\net47\SurveyMonkeyApi.dll" />
         <file src="bin\Release\net471\SurveyMonkeyApi.dll" target="lib\net471\SurveyMonkeyApi.dll" />
-        <file src="bin\Release\netcoreapp2.0\SurveyMonkeyApi.dll" target="lib\netcoreapp2.0\SurveyMonkeyApi.dll" />
+        <file src="bin\Release\netcoreapp2.1\SurveyMonkeyApi.dll" target="lib\netcoreapp2.1\SurveyMonkeyApi.dll" />
         <file src="bin\Release\net5.0\SurveyMonkeyApi.dll" target="lib\net5.0\SurveyMonkeyApi.dll" />
     </files>
 </package>

--- a/SurveyMonkey/SurveyMonkey.nuspec
+++ b/SurveyMonkey/SurveyMonkey.nuspec
@@ -13,7 +13,7 @@
         <summary />
         <copyright>Ben Emmett</copyright>
         <dependencies>
-            <dependency id="Newtonsoft.Json" version="10.0.3" />
+            <dependency id="Newtonsoft.Json" version="13.0.1" />
         </dependencies>
     </metadata>
     <files>
@@ -27,5 +27,6 @@
         <file src="bin\Release\net47\SurveyMonkeyApi.dll" target="lib\net47\SurveyMonkeyApi.dll" />
         <file src="bin\Release\net471\SurveyMonkeyApi.dll" target="lib\net471\SurveyMonkeyApi.dll" />
         <file src="bin\Release\netcoreapp2.0\SurveyMonkeyApi.dll" target="lib\netcoreapp2.0\SurveyMonkeyApi.dll" />
+        <file src="bin\Release\net5.0\SurveyMonkeyApi.dll" target="lib\net5.0\SurveyMonkeyApi.dll" />
     </files>
 </package>

--- a/SurveyMonkey/SurveyMonkeyApi.DataProcessing.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.DataProcessing.cs
@@ -216,7 +216,7 @@ namespace SurveyMonkey
                         PropertyInfo property = typeof(DemographicAnswer).GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
                         if (property != null)
                         {
-                            property.SetValue(reply, responseAnswer.Text, null);
+                            property.SetValue(reply, responseAnswer.Text);
                         }
                     }
                 }

--- a/SurveyMonkey/TolerantJsonConverter.cs
+++ b/SurveyMonkey/TolerantJsonConverter.cs
@@ -82,18 +82,18 @@ namespace SurveyMonkey
                                     convertedDate = rawDate;
                                     break;
                             }
-                            property.SetValue(instance, convertedDate, null);
+                            property.SetValue(instance, convertedDate);
                         }
                         else
                         {
                             if (property.Name == "Choices" && jsonProperty.Value.Type != JTokenType.Array)
                             {
                                 var legacyProperty = properties.FirstOrDefault(pi => String.Equals("LegacyChoices", pi.Name, StringComparison.OrdinalIgnoreCase));
-                                legacyProperty.SetValue(instance, jsonProperty.Value.ToObject(legacyProperty.PropertyType, serializer), null);
+                                legacyProperty.SetValue(instance, jsonProperty.Value.ToObject(legacyProperty.PropertyType, serializer));
                             }
                             else
                             {
-                                property.SetValue(instance, jsonProperty.Value.ToObject(property.PropertyType, serializer), null);
+                                property.SetValue(instance, jsonProperty.Value.ToObject(property.PropertyType, serializer));
                             }
                         }
                     }

--- a/SurveyMonkeyTests/JsonDeserializationTests.cs
+++ b/SurveyMonkeyTests/JsonDeserializationTests.cs
@@ -198,7 +198,7 @@ namespace SurveyMonkeyTests
         {
             string input = @"{""AnInt"":2134515487945}";
             var parsed = JObject.Parse(input);
-            Assert.Throws<OverflowException>(delegate { parsed.ToObject<JsonDeserializationTestsContainer>(); });
+            Assert.Throws<JsonReaderException>(delegate { parsed.ToObject<JsonDeserializationTestsContainer>(); });
         }
 
         [Test]

--- a/SurveyMonkeyTests/SurveyMonkeyTests.csproj
+++ b/SurveyMonkeyTests/SurveyMonkeyTests.csproj
@@ -22,16 +22,16 @@
     <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SurveyMonkey\SurveyMonkey.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>15.5.0</Version>
+      <Version>16.11.0</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/SurveyMonkeyTests/SurveyMonkeyTests.csproj
+++ b/SurveyMonkeyTests/SurveyMonkeyTests.csproj
@@ -16,7 +16,7 @@
     <DelaySign>false</DelaySign>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
-    <TargetFrameworks>net40;net45;net451;net451;net452;net46;net461;net462;net47;net471;netcoreapp2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net451;net451;net452;net46;net461;net462;net47;net471;netcoreapp2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <TargetFramework>net5.0</TargetFramework>

--- a/SurveyMonkeyTests/SurveyMonkeyTests.csproj
+++ b/SurveyMonkeyTests/SurveyMonkeyTests.csproj
@@ -16,10 +16,10 @@
     <DelaySign>false</DelaySign>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
-    <TargetFrameworks>net40;net45;net451;net451;net452;net46;net461;net462;net47;net471;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net451;net451;net452;net46;net461;net462;net47;net471;netcoreapp2.0;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/SurveyMonkeyTests/SurveyMonkeyTests.csproj
+++ b/SurveyMonkeyTests/SurveyMonkeyTests.csproj
@@ -16,7 +16,7 @@
     <DelaySign>false</DelaySign>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
-    <TargetFrameworks>net40;net45;net451;net451;net452;net46;net461;net462;net47;net471;netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;net451;net451;net452;net46;net461;net462;net47;net471;netcoreapp2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <TargetFramework>net5.0</TargetFramework>
@@ -29,7 +29,7 @@
   <ItemGroup>
     <ProjectReference Include="..\SurveyMonkey\SurveyMonkey.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
       <Version>16.11.0</Version>
     </PackageReference>


### PR DESCRIPTION
- Build for .NET 5, and prefer targeting that by default instead of a legacy .NET Framework 4.7.2 project.
- .NET Core 2.0 support dropped and replaced by Core 2.1 support (Core 2.0 SDK isn't available on AppVeyor's VS2019 build images, which are needed for .NET 5 - [see details](https://www.appveyor.com/docs/windows-images-software/#net-framework).
- Drops .NET 4.0 support, which was end-of-lifed by Microsoft back in 2016 (support for which forced use of a more verbose overload for SetProperty).
- Also upgrade some dependencies.