### PR TITLE
Improve packaging

### DIFF
--- a/SurveyMonkey/SurveyMonkey.csproj
+++ b/SurveyMonkey/SurveyMonkey.csproj
@@ -16,7 +16,7 @@
     <DelaySign>false</DelaySign>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
-    <TargetFrameworks>net45;net451;net451;net452;net46;net461;net462;net47;net471;netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <TargetFramework>net5.0</TargetFramework>

--- a/SurveyMonkey/SurveyMonkey.csproj
+++ b/SurveyMonkey/SurveyMonkey.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Company>Walnut Tree Software</Company>
-    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
-    <AssemblyInformationalVersion>1.0.0.0</AssemblyInformationalVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+    <InformationalVersion>1.0.0.0</InformationalVersion>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <Product>SurveyMonkeyApi</Product>
     <Title>SurveyMonkeyApi</Title>

--- a/SurveyMonkey/SurveyMonkey.nuspec
+++ b/SurveyMonkey/SurveyMonkey.nuspec
@@ -18,14 +18,6 @@
     </metadata>
     <files>
         <file src="bin\Release\net45\SurveyMonkeyApi.dll" target="lib\net45\SurveyMonkeyApi.dll" />
-        <file src="bin\Release\net451\SurveyMonkeyApi.dll" target="lib\net451\SurveyMonkeyApi.dll" />
-        <file src="bin\Release\net452\SurveyMonkeyApi.dll" target="lib\net452\SurveyMonkeyApi.dll" />
-        <file src="bin\Release\net46\SurveyMonkeyApi.dll" target="lib\net46\SurveyMonkeyApi.dll" />
-        <file src="bin\Release\net461\SurveyMonkeyApi.dll" target="lib\net461\SurveyMonkeyApi.dll" />
-        <file src="bin\Release\net462\SurveyMonkeyApi.dll" target="lib\net462\SurveyMonkeyApi.dll" />
-        <file src="bin\Release\net47\SurveyMonkeyApi.dll" target="lib\net47\SurveyMonkeyApi.dll" />
-        <file src="bin\Release\net471\SurveyMonkeyApi.dll" target="lib\net471\SurveyMonkeyApi.dll" />
-        <file src="bin\Release\netcoreapp2.1\SurveyMonkeyApi.dll" target="lib\netcoreapp2.1\SurveyMonkeyApi.dll" />
-        <file src="bin\Release\net5.0\SurveyMonkeyApi.dll" target="lib\net5.0\SurveyMonkeyApi.dll" />
+        <file src="bin\Release\netstandard2.0\SurveyMonkeyApi.dll" target="lib\netstandard2.0\SurveyMonkeyApi.dll" />
     </files>
 </package>

--- a/SurveyMonkeyTests/SurveyMonkeyTests.csproj
+++ b/SurveyMonkeyTests/SurveyMonkeyTests.csproj
@@ -16,7 +16,7 @@
     <DelaySign>false</DelaySign>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
-    <TargetFrameworks>net45;net451;net451;net452;net46;net461;net462;net47;net471;netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <TargetFramework>net5.0</TargetFramework>

--- a/SurveyMonkeyTests/SurveyMonkeyTests.csproj
+++ b/SurveyMonkeyTests/SurveyMonkeyTests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Company>Walnut Tree Software</Company>
-    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
-    <AssemblyInformationalVersion>1.0.0.0</AssemblyInformationalVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+    <InformationalVersion>1.0.0.0</InformationalVersion>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <Product>SurveyMonkeyApi</Product>
     <Title>SurveyMonkeyTests</Title>
@@ -25,13 +25,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SurveyMonkey\SurveyMonkey.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>16.11.0</Version>
-    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Now targets only .NET 4.5 (for legacy use) and .NET Standard 2.0 (which should get used most of the time).

Also fixes an issue with naming version properties in the csproj files which stopped AppVeyor patching versions properly and in turn meant the dlls within the nupkg files were left as 1.0.0.0 