### PR TITLE
Target tests at net5.0

### DIFF
--- a/SurveyMonkeyTests/SurveyMonkeyTests.csproj
+++ b/SurveyMonkeyTests/SurveyMonkeyTests.csproj
@@ -16,7 +16,7 @@
     <DelaySign>false</DelaySign>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <TargetFramework>net5.0</TargetFramework>


### PR DESCRIPTION
Sensible to run the tests against a version of .NET Core (5.0) as well as .NET Framework (4.5).