### PR TITLE
Fix how email addresses are surfaced in responses to email collectors

### DIFF
--- a/SurveyMonkey/Containers/MetadataTypeValuePair.cs
+++ b/SurveyMonkey/Containers/MetadataTypeValuePair.cs
@@ -1,0 +1,9 @@
+﻿namespace SurveyMonkey.Containers
+{
+    [Newtonsoft.Json.JsonConverter(typeof(TolerantJsonConverter))]
+    internal class MetadataTypeValuePair
+    {
+        public string Type { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/SurveyMonkey/Containers/Response.cs
+++ b/SurveyMonkey/Containers/Response.cs
@@ -19,7 +19,6 @@ namespace SurveyMonkey.Containers
         public string EditUrl { get; set; }
         public string AnalyzeUrl { get; set; }
         public Dictionary<string, object> LogicPath { get; set; } //TODO this structure isn't documented
-        public Dictionary<string, object> Metadata { get; set; } //TODO this structure isn't documented
         public List<object> PagePath { get; set; } //TODO this structure isn't documented
         public DateTime? DateCreated { get; set; }
         public DateTime? DateModified { get; set; }
@@ -30,6 +29,7 @@ namespace SurveyMonkey.Containers
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string EmailAddress { get; set; } //Described as "email" in SurveyMonkey's docs, but actually returned as "email_address" by the api.
+        internal ResponseMetadata Metadata { get; set; } // this structure isn't documented
         public List<ResponsePage> Pages { get; set; }
         public QuizResults QuizResults { get; set; }
 

--- a/SurveyMonkey/Containers/Response.cs
+++ b/SurveyMonkey/Containers/Response.cs
@@ -28,8 +28,38 @@ namespace SurveyMonkey.Containers
         public long? RecipientId { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
-        public string EmailAddress { get; set; } //Described as "email" in SurveyMonkey's docs, but actually returned as "email_address" by the api.
+
+        /*
+         * SurveyMonkey's docs say that for an email collector, responses will have a property "email". I've never
+         * seen that property exist. There does appear to always be a property email_address, which has always
+         * been an empty string. Finally, they have an undocumented metadata object, with a contact which has
+         * key value pair properties for first_name, last_name, custom_value, and email. The first_name,
+         * last_name, and custom_value properties also exist duplicated as root properties on the response object.
+         * Suspect that their intention was to do that with email too, and that they've misnamed the root email property
+         * as email_address in a way which prevents the data being populated correctly but still makes it appear as
+         * an empty string.
+         *
+         * Approach will be to internally deserialise each of the 3x places they could theoretically present the email
+         * address, and then the public api surface exposes only reading from EmailAddress, a property that looks at each and
+         * presents the first non-null non-empty one it finds, if at all. Some tests for this in GetResponseTests, and this
+         * can all be removed if SurveyMonkey fix the error & expose the email as documented.
+         *
+         * Metadata's structure is undocumented, so some danger that if there are other contexts in which it's also used
+         * but with a different structure, it could break the deserialiser.
+         */
         internal ResponseMetadata Metadata { get; set; } // this structure isn't documented
+        [JsonProperty("email")]
+        internal string EmailFromDirectReferenceToEmail { get; set; }
+        [JsonProperty("email_address")]
+        internal string EmailFromDirectReferenceToEmailAddress { get; set; }
+        [JsonIgnore]
+        public string EmailAddress =>
+            !String.IsNullOrWhiteSpace(EmailFromDirectReferenceToEmail) ? EmailFromDirectReferenceToEmail :
+                !String.IsNullOrWhiteSpace(EmailFromDirectReferenceToEmailAddress) ? EmailFromDirectReferenceToEmailAddress :
+                    Metadata?.Contact != null && Metadata.Contact.ContainsKey("email") ?
+                        !String.IsNullOrWhiteSpace(Metadata.Contact["email"].Value) ? Metadata.Contact["email"].Value :
+                        null : null;
+
         public List<ResponsePage> Pages { get; set; }
         public QuizResults QuizResults { get; set; }
 

--- a/SurveyMonkey/Containers/ResponseMetadata.cs
+++ b/SurveyMonkey/Containers/ResponseMetadata.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SurveyMonkey.Containers
+{
+    [JsonConverter(typeof(TolerantJsonConverter))]
+    internal class ResponseMetadata
+    {
+        internal Dictionary<string, MetadataTypeValuePair> Contact { get; set; }
+    }
+}

--- a/SurveyMonkeyTests/GetResponseTests.cs
+++ b/SurveyMonkeyTests/GetResponseTests.cs
@@ -32,7 +32,6 @@ namespace SurveyMonkeyTests
             Assert.AreEqual(String.Empty, results.First().CustomValue);
             Assert.IsEmpty(results.First().LogicPath);
             Assert.IsEmpty(results.First().PagePath);
-            Assert.IsEmpty(results.First().Metadata);
             Assert.AreEqual(123456789, results.First().RecipientId);
             Assert.AreEqual(84672934, results.First().SurveyId);
             Assert.AreEqual(91395530, results.First().CollectorId);
@@ -103,7 +102,6 @@ namespace SurveyMonkeyTests
             Assert.AreEqual(String.Empty, results.First().CustomValue);
             Assert.IsEmpty(results.First().LogicPath);
             Assert.IsEmpty(results.First().PagePath);
-            Assert.IsEmpty(results.First().Metadata);
             Assert.IsNull(results.First().RecipientId);
             Assert.AreEqual(84672934, results.First().SurveyId);
             Assert.AreEqual(91395530, results.First().CollectorId);
@@ -277,7 +275,6 @@ namespace SurveyMonkeyTests
             Assert.AreEqual(4968420283, result.Id);
             Assert.AreEqual("18.187.48.612", result.IpAddress);
             Assert.IsEmpty(result.LogicPath);
-            Assert.IsEmpty(result.Metadata);
             Assert.IsEmpty(result.PagePath);
             Assert.IsNull(result.RecipientId);
             Assert.AreEqual(ResponseStatus.Completed, result.ResponseStatus);
@@ -312,7 +309,6 @@ namespace SurveyMonkeyTests
             Assert.AreEqual(4968420283, result.Id);
             Assert.AreEqual("18.187.48.612", result.IpAddress);
             Assert.IsEmpty(result.LogicPath);
-            Assert.IsEmpty(result.Metadata);
             Assert.IsEmpty(result.PagePath);
             Assert.IsNull(result.RecipientId);
             Assert.AreEqual(ResponseStatus.Completed, result.ResponseStatus);

--- a/SurveyMonkeyTests/JsonDeserializationTests.cs
+++ b/SurveyMonkeyTests/JsonDeserializationTests.cs
@@ -487,6 +487,25 @@ namespace SurveyMonkeyTests
             Assert.AreEqual(5, result.AnInt);
         }
 
+        [Test]
+        public void IgnoreAttributeIsRespected()
+        {
+            string input = @"{""a_string"":""hi"",""an_ignored_property"":""asdf""}";
+            var parsed = JObject.Parse(input);
+            var output = parsed.ToObject<JsonDeserializationTestsContainer>();
+            Assert.AreEqual("hi", output.AString);
+            Assert.IsNull(output.AnIgnoredProperty);
+        }
+
+        [Test]
+        public void OverriddenPropertyNamesAreDeserialised()
+        {
+            string input = @"{""was_redirected"":""hi""}";
+            var parsed = JObject.Parse(input);
+            var output = parsed.ToObject<JsonDeserializationTestsContainer>();
+            Assert.AreEqual("hi", output.ARedirectedProperty);
+        }
+
         #endregion
 
         #region ObjectsHaveBeenWrittenToUseCorrectTypesAndConverters
@@ -549,6 +568,10 @@ namespace SurveyMonkeyTests
         public int? AnInt { get; set; }
         public EnumType? AnEnum { get; set; }
         public bool? ABool { get; set; }
+        [JsonIgnore]
+        public string AnIgnoredProperty { get; set; }
+        [JsonProperty("was_redirected")]
+        public string ARedirectedProperty { get; set; }
     }
 
     internal class WarningSupressingTolerantJsonConverter : TolerantJsonConverter


### PR DESCRIPTION
This is a workaround for a bug in how SurveyMonkey presents the `email` field for responses which came from email collectors.

SurveyMonkey's docs say that for an email collector, responses will have a property `email`. I've never seen that property exist. There does appear to always be a property `email_address`, which has always been an empty string. Finally, they have an undocumented `metadata` object, with a `contact` which has key value pair properties for `first_name`, `last_name`, `custom_value`, and `email`. The `first_name`, `last_name`, and `custom_value` properties also exist duplicated as root properties on the `response` object. Suspect that their intention was to do that with `email` too, and that they've misnamed the root `email` property as `email_address` in a way which prevents the data being populated correctly but still makes a property appear as an empty string.

This PR internally deserialises each of the 3x places I've seen them try to present the email address, and then the public api surface exposes only reading from `EmailAddress`, a property that looks at each of the internal ones and presents the first non-null non-empty one it finds, if at all. Also adds some tests for how that information's deserialised and presented.

This can all be removed if SurveyMonkey fix the error & expose the email as documented.

Metadata's structure is undocumented, so some danger that if there are other contexts in which it's also used but with a different structure, it could break the deserialiser, but think this is fairly unlikely.