### PR TITLE
Undocumented Collector and ResponseAnswer properties

### DIFF
--- a/SurveyMonkey/Containers/Collector.cs
+++ b/SurveyMonkey/Containers/Collector.cs
@@ -70,7 +70,13 @@ namespace SurveyMonkey.Containers
         public DateTime? DateCreated { get; set; }
         public string Url { get; set; }
         public bool? PasswordEnabled { get; set; }
-        public string SenderEmail { get; set; }
+        [JsonProperty("sender_email")] // /surveys/{id}/collectors [GetCollectorOverList(surveyId)] names the sender email as "email"
+        internal string EmailFromSenderEmail { get; set; }
+        [JsonProperty("email")] // /collectors/{id} [GetCollectorDetails(collectorId)] names the sender email as "sender_email"
+        internal string EmailFromEmail { get; set; }
+        [JsonIgnore]
+        public string SenderEmail =>
+            !String.IsNullOrWhiteSpace(EmailFromSenderEmail) ? EmailFromSenderEmail : EmailFromEmail;
         internal string Href { get; set; }
         public int? ResponseCount { get; set; }
         public int? Width { get; set; }

--- a/SurveyMonkey/Containers/Collector.cs
+++ b/SurveyMonkey/Containers/Collector.cs
@@ -77,6 +77,7 @@ namespace SurveyMonkey.Containers
         [JsonIgnore]
         public string SenderEmail =>
             !String.IsNullOrWhiteSpace(EmailFromSenderEmail) ? EmailFromSenderEmail : EmailFromEmail;
+        public bool? IsSenderEmailVerified { get; set; } //Undocumented
         internal string Href { get; set; }
         public int? ResponseCount { get; set; }
         public int? Width { get; set; }

--- a/SurveyMonkey/Containers/ResponseAnswer.cs
+++ b/SurveyMonkey/Containers/ResponseAnswer.cs
@@ -14,5 +14,7 @@ namespace SurveyMonkey.Containers
         public int? Score { get; set; }
         [JsonIgnore]
         internal object TagData { get; set; }
+        [JsonIgnore]
+        internal object ChoiceMetadata { get; set; } //Undocumented. Available by mapping to the survey structure
     }
 }


### PR DESCRIPTION
- Ignore undocumented metadata on ResponseAnswer (could be useful in getting choice info in a matrix rating question, but seems not to be present for the other question types which this concept would be useful for. The data's already available by mapping by ChoiceId to the survey structure, which is what PopulateSurveyResponseInformation does.
- When getting collector details, the api unhelpfully names the property differently depending on whether getting an overview of all collectors vs getting the details of a single collector. Work around that by deserialising to internal properties and presenting a single public property which examines both.
- Add undocumented is_sender_email_verified property.