### PR TITLE
Improve choosing of access urls

### DIFF
--- a/SurveyMonkey/SurveyMonkeyApi.Infrastructure.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Infrastructure.cs
@@ -97,7 +97,7 @@ namespace SurveyMonkey
             RateLimit();
             ResetWebClient();
 
-            var url = "https://api.surveymonkey.net/v3" + endpoint;
+            var url = "https://api.surveymonkey.com/v3" + endpoint;
             _webClient.Headers.Add("Content-Type", "application/json");
             _webClient.Headers.Add("Authorization", "bearer " + _accessToken);
             if (verb == Verb.GET)

--- a/SurveyMonkey/SurveyMonkeyApi.Infrastructure.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Infrastructure.cs
@@ -19,6 +19,7 @@ namespace SurveyMonkey
         private DateTime _lastRequestTime = DateTime.MinValue;
         private readonly int _rateLimitDelay = 500;
         private readonly int[] _retrySequence = { 5, 30, 300, 900 };
+        private readonly string _baseAccessUrl = "https://api.surveymonkey.com";
         private int _requestsMade;
 
         /// <summary>
@@ -34,21 +35,21 @@ namespace SurveyMonkey
 
         /// <param name="accessToken">The Access Token, representing either a private app's access token, or the long-lived token granted by an OAuth 2.0 flow.</param>
         public SurveyMonkeyApi(string accessToken)
-            : this(accessToken, null, null, null)
+            : this(accessToken, null, null, null, null)
         {
         }
 
         /// <param name="accessToken">The Access Token, representing either a private app's access token, or the long-lived token granted by an OAuth 2.0 flow.</param>
         /// <param name="rateLimitDelay">The number of milliseconds to wait between each api request. 500ms by default to accomodate SurveyMonkey's default 120/s limit. Set to a lower number if you have been granted a higher rate limit.</param>
         public SurveyMonkeyApi(string accessToken, int rateLimitDelay)
-            : this(accessToken, rateLimitDelay, null, null)
+            : this(accessToken, rateLimitDelay, null, null, null)
         {
         }
 
         /// <param name="accessToken">The Access Token, representing either a private app's access token, or the long-lived token granted by an OAuth 2.0 flow.</param>
         /// <param name="retrySequence">A sequence of the number of seconds to wait between retries if connectivity issues are encountered. Defaults to 5, 30, 300, then 900 seconds.</param>
         public SurveyMonkeyApi(string accessToken, int[] retrySequence)
-            : this(accessToken, null, retrySequence, null)
+            : this(accessToken, null, retrySequence, null, null)
         {
         }
 
@@ -56,26 +57,58 @@ namespace SurveyMonkey
         /// <param name="rateLimitDelay">The number of milliseconds to wait between each api request. 500ms by default to accomodate SurveyMonkey's default 120/s limit. Set to a lower number if you have been granted a higher rate limit.</param>
         /// <param name="retrySequence">A sequence of the number of seconds to wait between retries if connectivity issues are encountered. Defaults to 5, 30, 300, then 900 seconds.</param>
         public SurveyMonkeyApi(string accessToken, int rateLimitDelay, int[] retrySequence)
-            : this(accessToken, rateLimitDelay, retrySequence, null)
+            : this(accessToken, rateLimitDelay, retrySequence, null, null)
+        {
+        }
+
+        /// <param name="accessToken">The Access Token, representing either a private app's access token, or the long-lived token granted by an OAuth 2.0 flow.</param>
+        /// <param name="accessUrl">Use to connect to an api access url other than the default https://api.surveymonkey.com.</param>
+        public SurveyMonkeyApi(string accessToken, string accessUrl)
+            : this(accessToken, null, null, accessUrl, null)
+        {
+        }
+
+        /// <param name="accessToken">The Access Token, representing either a private app's access token, or the long-lived token granted by an OAuth 2.0 flow.</param>
+        /// <param name="rateLimitDelay">The number of milliseconds to wait between each api request. 500ms by default to accomodate SurveyMonkey's default 120/s limit. Set to a lower number if you have been granted a higher rate limit.</param>
+        /// <param name="accessUrl">Use to connect to an api access url other than the default https://api.surveymonkey.com.</param>
+        public SurveyMonkeyApi(string accessToken, int rateLimitDelay, string accessUrl)
+            : this(accessToken, rateLimitDelay, null, accessUrl, null)
+        {
+        }
+
+        /// <param name="accessToken">The Access Token, representing either a private app's access token, or the long-lived token granted by an OAuth 2.0 flow.</param>
+        /// <param name="retrySequence">A sequence of the number of seconds to wait between retries if connectivity issues are encountered. Defaults to 5, 30, 300, then 900 seconds.</param>
+        /// <param name="accessUrl">Use to connect to an api access url other than the default https://api.surveymonkey.com.</param>
+        public SurveyMonkeyApi(string accessToken, int[] retrySequence, string accessUrl)
+            : this(accessToken, null, retrySequence, accessUrl, null)
+        {
+        }
+
+        /// <param name="accessToken">The Access Token, representing either a private app's access token, or the long-lived token granted by an OAuth 2.0 flow.</param>
+        /// <param name="rateLimitDelay">The number of milliseconds to wait between each api request. 500ms by default to accomodate SurveyMonkey's default 120/s limit. Set to a lower number if you have been granted a higher rate limit.</param>
+        /// <param name="retrySequence">A sequence of the number of seconds to wait between retries if connectivity issues are encountered. Defaults to 5, 30, 300, then 900 seconds.</param>
+        /// <param name="accessUrl">Use to connect to an api access url other than the default https://api.surveymonkey.com.</param>
+        public SurveyMonkeyApi(string accessToken, int rateLimitDelay, int[] retrySequence, string accessUrl)
+            : this(accessToken, rateLimitDelay, retrySequence, accessUrl, null)
         {
         }
 
         internal SurveyMonkeyApi(string accessToken, IWebClient webClient)
-            : this(accessToken, 0, null, webClient)
+            : this(accessToken, 0, null, null, webClient)
         {
         }
 
         internal SurveyMonkeyApi(string accessToken, IWebClient webClient, int rateLimitDelay)
-            : this(accessToken, rateLimitDelay, null, webClient)
+            : this(accessToken, rateLimitDelay, null, null, webClient)
         {
         }
 
         internal SurveyMonkeyApi(string accessToken, IWebClient webClient, int[] retrySequence)
-            : this(accessToken, null, retrySequence, webClient)
+            : this(accessToken, null, retrySequence, null, webClient)
         {
         }
 
-        private SurveyMonkeyApi(string accessToken, int? rateLimitDelay, int[] retrySequence, IWebClient webClient)
+        private SurveyMonkeyApi(string accessToken, int? rateLimitDelay, int[] retrySequence, string accessUrl, IWebClient webClient)
         {
             _webClient = webClient ?? new LiveWebClient();
             _webClient.Encoding = Encoding.UTF8;
@@ -90,6 +123,15 @@ namespace SurveyMonkey
             {
                 _retrySequence = retrySequence;
             }
+
+            if (accessUrl != null)
+            {
+                if (!accessUrl.StartsWith("http"))
+                {
+                    throw new ArgumentException($"Invalid url {accessUrl} given. Base access url must be a full url, eg \"https://api.eu.surveymonkey.com\"");
+                }
+                _baseAccessUrl = accessUrl;
+            }
         }
 
         private JToken MakeApiRequest(string endpoint, Verb verb, RequestData data)
@@ -97,7 +139,7 @@ namespace SurveyMonkey
             RateLimit();
             ResetWebClient();
 
-            var url = "https://api.surveymonkey.com/v3" + endpoint;
+            var url = $"{_baseAccessUrl}/v3{endpoint}";
             _webClient.Headers.Add("Content-Type", "application/json");
             _webClient.Headers.Add("Authorization", "bearer " + _accessToken);
             if (verb == Verb.GET)

--- a/SurveyMonkeyTests/GetResponseTests.cs
+++ b/SurveyMonkeyTests/GetResponseTests.cs
@@ -217,40 +217,40 @@ namespace SurveyMonkeyTests
             var api = new SurveyMonkeyApi("TestOAuthToken", client);
 
             api.GetSurveyResponseDetailsList(1);
-            Assert.AreEqual(@"https://api.surveymonkey.net/v3/surveys/1/responses/bulk", client.Requests.Last().Url);
+            Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/1/responses/bulk", client.Requests.Last().Url);
 
             api.GetCollectorResponseDetailsList(2);
-            Assert.AreEqual(@"https://api.surveymonkey.net/v3/collectors/2/responses/bulk", client.Requests.Last().Url);
+            Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/2/responses/bulk", client.Requests.Last().Url);
 
             api.GetSurveyResponseOverviewList(3);
-            Assert.AreEqual(@"https://api.surveymonkey.net/v3/surveys/3/responses", client.Requests.Last().Url);
+            Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/3/responses", client.Requests.Last().Url);
 
             api.GetCollectorResponseOverviewList(4);
-            Assert.AreEqual(@"https://api.surveymonkey.net/v3/collectors/4/responses", client.Requests.Last().Url);
+            Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/4/responses", client.Requests.Last().Url);
 
             api.GetSurveyResponseDetailsList(5, new GetResponseListSettings());
-            Assert.AreEqual(@"https://api.surveymonkey.net/v3/surveys/5/responses/bulk", client.Requests.Last().Url);
+            Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/5/responses/bulk", client.Requests.Last().Url);
 
             api.GetCollectorResponseDetailsList(6, new GetResponseListSettings());
-            Assert.AreEqual(@"https://api.surveymonkey.net/v3/collectors/6/responses/bulk", client.Requests.Last().Url);
+            Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/6/responses/bulk", client.Requests.Last().Url);
 
             api.GetSurveyResponseOverviewList(7,new GetResponseListSettings());
-            Assert.AreEqual(@"https://api.surveymonkey.net/v3/surveys/7/responses", client.Requests.Last().Url);
+            Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/7/responses", client.Requests.Last().Url);
 
             api.GetCollectorResponseOverviewList(8, new GetResponseListSettings());
-            Assert.AreEqual(@"https://api.surveymonkey.net/v3/collectors/8/responses", client.Requests.Last().Url);
+            Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/8/responses", client.Requests.Last().Url);
 
             api.GetSurveyResponseDetails(9, 10);
-            Assert.AreEqual(@"https://api.surveymonkey.net/v3/surveys/9/responses/10/details", client.Requests.Last().Url);
+            Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/9/responses/10/details", client.Requests.Last().Url);
 
             api.GetCollectorResponseDetails(11, 12);
-            Assert.AreEqual(@"https://api.surveymonkey.net/v3/collectors/11/responses/12/details", client.Requests.Last().Url);
+            Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/11/responses/12/details", client.Requests.Last().Url);
 
             api.GetSurveyResponseOverview(13, 14);
-            Assert.AreEqual(@"https://api.surveymonkey.net/v3/surveys/13/responses/14", client.Requests.Last().Url);
+            Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/13/responses/14", client.Requests.Last().Url);
 
             api.GetCollectorResponseOverview(15, 16);
-            Assert.AreEqual(@"https://api.surveymonkey.net/v3/collectors/15/responses/16", client.Requests.Last().Url);
+            Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/15/responses/16", client.Requests.Last().Url);
         }
 
         [Test]

--- a/SurveyMonkeyTests/WebClientInfrastructureTests.cs
+++ b/SurveyMonkeyTests/WebClientInfrastructureTests.cs
@@ -25,7 +25,7 @@ namespace SurveyMonkeyTests
             Assert.AreEqual("application/json", client.Requests.First().Headers["Content-Type"]);
             Assert.AreEqual("bearer TestOAuthToken", client.Requests.First().Headers["Authorization"]);
             Assert.AreEqual(Encoding.UTF8, client.Requests.First().Encoding);
-            Assert.AreEqual("https://api.surveymonkey.net/v3/surveys", client.Requests.First().Url);
+            Assert.AreEqual("https://api.surveymonkey.com/v3/surveys", client.Requests.First().Url);
         }
 
         [Test]


### PR DESCRIPTION
- Defaults to connecting to https://api.surveymonkey.com instead of https://api.surveymonkey.net. This was [changed silently in the docs in 2018](https://github.com/SurveyMonkey/public_api_docs/commit/44332e30d73b9dbf91e3c7b0e78fc4af36149947).
- Adds additional constructors allowing to manually specify an access url other than the default, now that other endpoints are available for EU and Canadian data centres.