### PR TITLE
Most robust handling of response contact info

### DIFF
--- a/SurveyMonkey/Containers/Response.cs
+++ b/SurveyMonkey/Containers/Response.cs
@@ -56,9 +56,7 @@ namespace SurveyMonkey.Containers
         public string EmailAddress =>
             !String.IsNullOrWhiteSpace(EmailFromDirectReferenceToEmail) ? EmailFromDirectReferenceToEmail :
                 !String.IsNullOrWhiteSpace(EmailFromDirectReferenceToEmailAddress) ? EmailFromDirectReferenceToEmailAddress :
-                    Metadata?.Contact != null && Metadata.Contact.ContainsKey("email") ?
-                        !String.IsNullOrWhiteSpace(Metadata.Contact["email"].Value) ? Metadata.Contact["email"].Value :
-                        null : null;
+                    Metadata?.GetValueByKeyOrNull("email");
 
         public List<ResponsePage> Pages { get; set; }
         public QuizResults QuizResults { get; set; }

--- a/SurveyMonkey/Containers/Response.cs
+++ b/SurveyMonkey/Containers/Response.cs
@@ -15,7 +15,6 @@ namespace SurveyMonkey.Containers
         internal string Href { get; set; }
         public Dictionary<string, string> CustomVariables { get; set; }
         public int? TotalTime { get; set; }
-        public string CustomValue { get; set; }
         public string EditUrl { get; set; }
         public string AnalyzeUrl { get; set; }
         public Dictionary<string, object> LogicPath { get; set; } //TODO this structure isn't documented
@@ -26,8 +25,6 @@ namespace SurveyMonkey.Containers
         public CollectionMode? CollectionMode { get; set; }
         public string IpAddress { get; set; }
         public long? RecipientId { get; set; }
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
 
         /*
          * SurveyMonkey's docs say that for an email collector, responses will have a property "email". I've never
@@ -59,6 +56,27 @@ namespace SurveyMonkey.Containers
             !String.IsNullOrWhiteSpace(EmailFromDirectReferenceToEmail) ? EmailFromDirectReferenceToEmail :
                 !String.IsNullOrWhiteSpace(EmailFromDirectReferenceToEmailAddress) ? EmailFromDirectReferenceToEmailAddress :
                     Metadata?.GetValueByKeyOrNull("email");
+
+        /*
+         * Because of the fragility of how the api presents contact data for email responses and how it's duplicated in the metadata
+         * object in an undocumented way, we'll also look for first_name, last_name, and custom_value info there in case they
+         * change that behaviour in the future.
+         */
+
+        [JsonProperty("first_name")]
+        internal string FirstNameFromDirectReference { get; set; }
+        [JsonIgnore]
+        public string FirstName => FirstNameFromDirectReference ?? Metadata?.GetValueByKeyOrNull("first_name");
+
+        [JsonProperty("last_name")]
+        internal string LastNameFromDirectReference { get; set; }
+        [JsonIgnore]
+        public string LastName => LastNameFromDirectReference ?? Metadata?.GetValueByKeyOrNull("last_name");
+
+        [JsonProperty("custom_value")]
+        internal string CustomValueFromDirectReference { get; set; }
+        [JsonIgnore]
+        public string CustomValue => CustomValueFromDirectReference ?? Metadata?.GetValueByKeyOrNull("custom_value");
 
         public List<ResponsePage> Pages { get; set; }
         public QuizResults QuizResults { get; set; }

--- a/SurveyMonkey/Containers/Response.cs
+++ b/SurveyMonkey/Containers/Response.cs
@@ -32,10 +32,12 @@ namespace SurveyMonkey.Containers
         /*
          * SurveyMonkey's docs say that for an email collector, responses will have a property "email". I've never
          * seen that property exist. There does appear to always be a property email_address, which has always
-         * been an empty string. Finally, they have an undocumented metadata object, with a contact which has
-         * key value pair properties for first_name, last_name, custom_value, and email. The first_name,
-         * last_name, and custom_value properties also exist duplicated as root properties on the response object.
-         * Suspect that their intention was to do that with email too, and that they've misnamed the root email property
+         * been an empty string when retrieving responses in bulk, and is populated when retrieving an individual response.
+         * Finally, they have an undocumented metadata object, with a contact which has key value pair properties for
+         * first_name, last_name, custom_value, and email when retriving responses in bulk, and the same when
+         * retrieving an individual response but with the email property bring populated. The first_name, last_name,
+         * and custom_value properties also exist duplicated as root properties on the response object. Suspect
+         * that their intention was to do that with email too, and that they've misnamed the root email property
          * as email_address in a way which prevents the data being populated correctly but still makes it appear as
          * an empty string.
          *

--- a/SurveyMonkey/Containers/ResponseMetadata.cs
+++ b/SurveyMonkey/Containers/ResponseMetadata.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace SurveyMonkey.Containers
@@ -7,5 +8,23 @@ namespace SurveyMonkey.Containers
     internal class ResponseMetadata
     {
         internal Dictionary<string, MetadataTypeValuePair> Contact { get; set; }
+
+        internal string GetValueByKeyOrNull(string key)
+        {
+            if (Contact == null)
+            {
+                return null;
+            }
+            if (!Contact.ContainsKey(key))
+            {
+                return null;
+            }
+            string value = Contact[key].Value;
+            if (String.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+            return value;
+        }
     }
 }


### PR DESCRIPTION
first_name, last_name, and custom_value are also not well documented, and their value seem to be duplicated on the undocumented metadata object. Looking for the data there if the root object is null, in the same way as is done for email_address, in case they break this in the future.