### PR TITLE
Get mapped choice details from api

### DIFF
--- a/SurveyMonkey/Containers/ChoiceMetadata.cs
+++ b/SurveyMonkey/Containers/ChoiceMetadata.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+
+namespace SurveyMonkey.Containers
+{
+    [JsonConverter(typeof(TolerantJsonConverter))]
+    public class ChoiceMetadata
+    {
+        // Api docs say this is a string rather than an integer - probably an error but treating it as a string here just in case there's some scenario it can be
+        public string Weight { get; set; }
+    }
+}

--- a/SurveyMonkey/Containers/ResponseAnswer.cs
+++ b/SurveyMonkey/Containers/ResponseAnswer.cs
@@ -15,7 +15,6 @@ namespace SurveyMonkey.Containers
         public string SimpleText { get; set; }
         [JsonIgnore]
         internal object TagData { get; set; }
-        [JsonIgnore]
-        internal object ChoiceMetadata { get; set; } //Undocumented. Available by mapping to the survey structure
+        public ChoiceMetadata ChoiceMetadata { get; set; }
     }
 }

--- a/SurveyMonkey/Containers/ResponseAnswer.cs
+++ b/SurveyMonkey/Containers/ResponseAnswer.cs
@@ -12,6 +12,8 @@ namespace SurveyMonkey.Containers
         public string Text { get; set; }
         public bool? IsCorrect { get; set; }
         public int? Score { get; set; }
+        public string DownloadUrl { get; set; }
+        public string ContentType { get; set; }
         public string SimpleText { get; set; }
         [JsonIgnore]
         internal object TagData { get; set; }

--- a/SurveyMonkey/Containers/ResponseAnswer.cs
+++ b/SurveyMonkey/Containers/ResponseAnswer.cs
@@ -12,6 +12,7 @@ namespace SurveyMonkey.Containers
         public string Text { get; set; }
         public bool? IsCorrect { get; set; }
         public int? Score { get; set; }
+        public string SimpleText { get; set; }
         [JsonIgnore]
         internal object TagData { get; set; }
         [JsonIgnore]

--- a/SurveyMonkey/Containers/ResponseQuestion.cs
+++ b/SurveyMonkey/Containers/ResponseQuestion.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using SurveyMonkey.Enums;
 using SurveyMonkey.ProcessedAnswers;
 
 namespace SurveyMonkey.Containers
@@ -8,6 +9,9 @@ namespace SurveyMonkey.Containers
     public class ResponseQuestion
     {
         public long? Id { get; set; }
+        public QuestionFamily? Family { get; set; }
+        public QuestionSubtype? Subtype { get; set; }
+        public string Heading { get; set; }
         public long? VariableId { get; set; }
         public List<ResponseAnswer> Answers { get; set; }
 

--- a/SurveyMonkey/Helpers/RequestSettingsHelper.cs
+++ b/SurveyMonkey/Helpers/RequestSettingsHelper.cs
@@ -38,6 +38,10 @@ namespace SurveyMonkey.Helpers
                     {
                         output.Add(PropertyCasingHelper.CamelToSnake(property.Name), ((List<long>)property.GetValue(obj)).ConvertAll(x => x.ToString()));
                     }
+                    else if (underlyingType == typeof(bool))
+                    {
+                        output.Add(PropertyCasingHelper.CamelToSnake(property.Name), PropertyCasingHelper.CamelToSnake(property.GetValue(obj).ToString()));
+                    }
                     else
                     {
                         output.Add(PropertyCasingHelper.CamelToSnake(property.Name), property.GetValue(obj));

--- a/SurveyMonkey/RequestSettings/GetResponseListSettings.cs
+++ b/SurveyMonkey/RequestSettings/GetResponseListSettings.cs
@@ -41,5 +41,6 @@ namespace SurveyMonkey.RequestSettings
         public TotalTimeUnitsOption? TotalTimeUnits { get; set; }
         public SortOrderOption? SortOrder { get; set; }
         public SortByOption? SortBy { get; set; }
+        internal bool? Simple { get; set; }
     }
 }

--- a/SurveyMonkey/SurveyMonkeyApi.Responses.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Responses.cs
@@ -38,7 +38,7 @@ namespace SurveyMonkey
         private Response GetResponseRequest(long objectId, ObjectType source, long responseId, bool details)
         {
             var detailString = details ? "/details" : String.Empty;
-            string endPoint = String.Format("/{0}s/{1}/responses/{2}{3}", source.ToString().ToLower(), objectId, responseId, detailString);
+            string endPoint = $"/{source.ToString().ToLower()}s/{objectId}/responses/{responseId}{detailString}";
             var verb = Verb.GET;
             JToken result = MakeApiRequest(endPoint, verb, new RequestData());
             var responses = result.ToObject<Response>();
@@ -92,7 +92,7 @@ namespace SurveyMonkey
         private List<Response> GetResponseListPager(long id, ObjectType objectType, IPagingSettings settings, bool details)
         {
             var bulk = details ? "/bulk" : String.Empty;
-            string endPoint = String.Format("/{0}s/{1}/responses{2}", objectType.ToString().ToLower(), id, bulk);
+            string endPoint = $"/{objectType.ToString().ToLower()}s/{id}/responses{bulk}";
             int maxResultsPerPage = details ? 100 : 1000;
             var results = Page(settings, endPoint, typeof(List<Response>), maxResultsPerPage);
             return results.ToList().ConvertAll(o => (Response)o);

--- a/SurveyMonkey/SurveyMonkeyApi.Responses.cs
+++ b/SurveyMonkey/SurveyMonkeyApi.Responses.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using SurveyMonkey.Containers;
+using SurveyMonkey.Helpers;
 using SurveyMonkey.RequestSettings;
 
 namespace SurveyMonkey
@@ -40,7 +41,8 @@ namespace SurveyMonkey
             var detailString = details ? "/details" : String.Empty;
             string endPoint = $"/{source.ToString().ToLower()}s/{objectId}/responses/{responseId}{detailString}";
             var verb = Verb.GET;
-            JToken result = MakeApiRequest(endPoint, verb, new RequestData());
+            var requestData = details ? RequestSettingsHelper.GetPopulatedProperties(new GetResponseListSettings{Simple = true}) : new RequestData();
+            JToken result = MakeApiRequest(endPoint, verb, requestData);
             var responses = result.ToObject<Response>();
             return responses;
         }
@@ -89,11 +91,12 @@ namespace SurveyMonkey
             return GetResponseListPager(collectorId, ObjectType.Collector, settings, true);
         }
 
-        private List<Response> GetResponseListPager(long id, ObjectType objectType, IPagingSettings settings, bool details)
+        private List<Response> GetResponseListPager(long id, ObjectType objectType, GetResponseListSettings settings, bool details)
         {
             var bulk = details ? "/bulk" : String.Empty;
             string endPoint = $"/{objectType.ToString().ToLower()}s/{id}/responses{bulk}";
             int maxResultsPerPage = details ? 100 : 1000;
+            settings.Simple = details ? true : null;
             var results = Page(settings, endPoint, typeof(List<Response>), maxResultsPerPage);
             return results.ToList().ConvertAll(o => (Response)o);
         }

--- a/SurveyMonkeyTests/GetResponseTests.cs
+++ b/SurveyMonkeyTests/GetResponseTests.cs
@@ -218,11 +218,11 @@ namespace SurveyMonkeyTests
 
             api.GetSurveyResponseDetailsList(1);
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/1/responses/bulk", client.Requests.Last().Url);
-            Assert.AreEqual("True", client.Requests.Last().QueryString["simple"]);
+            Assert.AreEqual("true", client.Requests.Last().QueryString["simple"]);
 
             api.GetCollectorResponseDetailsList(2);
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/2/responses/bulk", client.Requests.Last().Url);
-            Assert.AreEqual("True", client.Requests.Last().QueryString["simple"]);
+            Assert.AreEqual("true", client.Requests.Last().QueryString["simple"]);
 
             api.GetSurveyResponseOverviewList(3);
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/3/responses", client.Requests.Last().Url);
@@ -234,11 +234,11 @@ namespace SurveyMonkeyTests
 
             api.GetSurveyResponseDetailsList(5, new GetResponseListSettings());
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/5/responses/bulk", client.Requests.Last().Url);
-            Assert.AreEqual("True", client.Requests.Last().QueryString["simple"]);
+            Assert.AreEqual("true", client.Requests.Last().QueryString["simple"]);
 
             api.GetCollectorResponseDetailsList(6, new GetResponseListSettings());
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/6/responses/bulk", client.Requests.Last().Url);
-            Assert.AreEqual("True", client.Requests.Last().QueryString["simple"]);
+            Assert.AreEqual("true", client.Requests.Last().QueryString["simple"]);
 
             api.GetSurveyResponseOverviewList(7,new GetResponseListSettings());
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/7/responses", client.Requests.Last().Url);
@@ -250,11 +250,11 @@ namespace SurveyMonkeyTests
 
             api.GetSurveyResponseDetails(9, 10);
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/9/responses/10/details", client.Requests.Last().Url);
-            Assert.AreEqual("True", client.Requests.Last().QueryString["simple"]);
+            Assert.AreEqual("true", client.Requests.Last().QueryString["simple"]);
 
             api.GetCollectorResponseDetails(11, 12);
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/11/responses/12/details", client.Requests.Last().Url);
-            Assert.AreEqual("True", client.Requests.Last().QueryString["simple"]);
+            Assert.AreEqual("true", client.Requests.Last().QueryString["simple"]);
 
             api.GetSurveyResponseOverview(13, 14);
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/13/responses/14", client.Requests.Last().Url);

--- a/SurveyMonkeyTests/GetResponseTests.cs
+++ b/SurveyMonkeyTests/GetResponseTests.cs
@@ -218,39 +218,51 @@ namespace SurveyMonkeyTests
 
             api.GetSurveyResponseDetailsList(1);
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/1/responses/bulk", client.Requests.Last().Url);
+            Assert.AreEqual("True", client.Requests.Last().QueryString["simple"]);
 
             api.GetCollectorResponseDetailsList(2);
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/2/responses/bulk", client.Requests.Last().Url);
+            Assert.AreEqual("True", client.Requests.Last().QueryString["simple"]);
 
             api.GetSurveyResponseOverviewList(3);
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/3/responses", client.Requests.Last().Url);
+            Assert.IsNull(client.Requests.Last().QueryString["simple"]);
 
             api.GetCollectorResponseOverviewList(4);
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/4/responses", client.Requests.Last().Url);
+            Assert.IsNull(client.Requests.Last().QueryString["simple"]);
 
             api.GetSurveyResponseDetailsList(5, new GetResponseListSettings());
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/5/responses/bulk", client.Requests.Last().Url);
+            Assert.AreEqual("True", client.Requests.Last().QueryString["simple"]);
 
             api.GetCollectorResponseDetailsList(6, new GetResponseListSettings());
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/6/responses/bulk", client.Requests.Last().Url);
+            Assert.AreEqual("True", client.Requests.Last().QueryString["simple"]);
 
             api.GetSurveyResponseOverviewList(7,new GetResponseListSettings());
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/7/responses", client.Requests.Last().Url);
+            Assert.IsNull(client.Requests.Last().QueryString["simple"]);
 
             api.GetCollectorResponseOverviewList(8, new GetResponseListSettings());
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/8/responses", client.Requests.Last().Url);
+            Assert.IsNull(client.Requests.Last().QueryString["simple"]);
 
             api.GetSurveyResponseDetails(9, 10);
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/9/responses/10/details", client.Requests.Last().Url);
+            Assert.AreEqual("True", client.Requests.Last().QueryString["simple"]);
 
             api.GetCollectorResponseDetails(11, 12);
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/11/responses/12/details", client.Requests.Last().Url);
+            Assert.AreEqual("True", client.Requests.Last().QueryString["simple"]);
 
             api.GetSurveyResponseOverview(13, 14);
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/surveys/13/responses/14", client.Requests.Last().Url);
+            Assert.IsNull(client.Requests.Last().QueryString["simple"]);
 
             api.GetCollectorResponseOverview(15, 16);
             Assert.AreEqual(@"https://api.surveymonkey.com/v3/collectors/15/responses/16", client.Requests.Last().Url);
+            Assert.IsNull(client.Requests.Last().QueryString["simple"]);
         }
 
         [Test]


### PR DESCRIPTION
Pass "simple" property to the api whenever we're making requests for response details (but not if we're only asking for overviews), so that we get back the mapped description of the choice without having to do our own mapping by separately retrieving the survey structure.